### PR TITLE
bug fix

### DIFF
--- a/src/code.sh
+++ b/src/code.sh
@@ -16,6 +16,9 @@ _dias_report_setup () {
 
         if [ "$workflow_id" != "null" ]; then
             workflow_name=$(dx describe --json "${workflow_id}" | jq -r '.executableName')
+        else
+            # unset from null string if not from workflow
+            unset workflow_id
         fi
     fi
 


### PR DESCRIPTION
- fix for unsetting workflow ID when set to `null` for a VCF not generated as part of a workflow

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_workbook/75)
<!-- Reviewable:end -->
