### PR TITLE
fix gnomad AFs being numeric type in URL instead of forcing to string

### DIFF
--- a/resources/home/dnanexus/generate_workbook/utils/vcf.py
+++ b/resources/home/dnanexus/generate_workbook/utils/vcf.py
@@ -455,6 +455,9 @@ class vcf():
             url = url.replace('POS', str(value.POS))
             url = url.replace('REF', str(value.REF))
             url = url.replace('ALT', str(value.ALT))
+
+            return f'=HYPERLINK("{url}", {value[column]})'
+
         elif 'mastermind' in column.lower() or 'mmid3' in column.lower():
             # build URL for MasterMind on genomic position
             # get chromosome NC value for given chrom and build


### PR DESCRIPTION
- keeps gnomAD AFs as numeric type instead of strings to allow correct filtering on columns
- example output: https://platform.dnanexus.com/projects/G9Q2B8843VxFBb9Y4j3PJ0g6/monitor/job/G9xxQy043Vx02jb8Fpg4g14p

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_workbook/78)
<!-- Reviewable:end -->
