### PR TITLE
fix broken unit tests

### DIFF
--- a/resources/home/dnanexus/generate_workbook/tests/pytest.ini
+++ b/resources/home/dnanexus/generate_workbook/tests/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    ignore:.*U.*mode is deprecated:DeprecationWarning

--- a/resources/home/dnanexus/generate_workbook/tests/test_columns.py
+++ b/resources/home/dnanexus/generate_workbook/tests/test_columns.py
@@ -68,27 +68,27 @@ class TestInfoColumn():
         )
 
 
-    def test_parsed_correct_gnomAD_AF_values(self):
+    def test_parsed_correct_gnomADe_AF_values(self):
         """
-        Test values read into dataframe for gnomAD_AF match the values
+        Test values read into dataframe for gnomADe_AF match the values
         above from the VCF
         """
-        # read gnomAD_AF values from vcf
+        # read gnomADe_AF values from vcf
         output = subprocess.run(
             (
                 f"grep -v '^#' {self.test_vcf} | grep -oh "
-                f"'gnomAD_AF=[0-9\.e\-]*;' | sort | uniq"
+                f"'gnomADe_AF=[0-9\.e\-]*;' | sort | uniq"
             ), shell=True, capture_output=True
         )
 
         # clean up values
         stdout = output.stdout.decode().splitlines()
         stdout = sorted(list([
-            x.replace(';', '').replace('gnomAD_AF=', '') for x in stdout
+            x.replace(';', '').replace('gnomADe_AF=', '') for x in stdout
         ]))
 
         # get AF values from dataframe
-        df_values = sorted(list(self.vcf_df['CSQ_gnomAD_AF'].unique().tolist()))
+        df_values = sorted(list(self.vcf_df['CSQ_gnomADe_AF'].unique().tolist()))
 
         assert all([str(x) == str(y) for x, y in zip(stdout, df_values)]), (
             "gnomAD AF values in VCF do not match those in dataframe"
@@ -101,12 +101,11 @@ class TestFormatSample():
     fields, combining with respective values from SAMPLE column
     """
     # run dataframe through splitColumns.format_fields() to split out FORMAT/SAMPLE
-    test_vcf = os.path.join(TEST_DATA_DIR, "NA12878_unittest.split.vcf")
+    test_vcf = os.path.join(TEST_DATA_DIR, "NA12878_unittest.vcf")
 
     # run dataframe through splitColumns.info() to split out INFO column
     vcf_df = read_test_vcf(vcf_file=test_vcf)
     vcf_df = splitColumns().split(vcf_df)
-
 
     # get list of FORMAT fields from VCF FORMAT column
     output = subprocess.run((
@@ -118,8 +117,8 @@ class TestFormatSample():
     # fields already present in df from INFO column will have had suffix added,
     # therefore we will check if they are there to select the correct fields
     for idx, field in enumerate(format_fields):
-        if f"{field} (FMT)" in vcf_df.columns:
-            format_fields[idx] = f"{field} (FMT)"
+        if f"{field}_FMT" in vcf_df.columns:
+            format_fields[idx] = f"{field}_FMT"
 
     # get all SAMPLE values from vcf
     output = subprocess.run((
@@ -147,7 +146,7 @@ class TestFormatSample():
 if __name__ == "__main__":
     info = TestInfoColumn()
     info.test_parsed_correct_columns_from_info_records()
-    info.test_parsed_correct_gnomAD_AF_values()
+    info.test_parsed_correct_gnomADe_AF_values()
 
     format = TestFormatSample()
     format.test_format_sample_values_are_correct()

--- a/resources/home/dnanexus/generate_workbook/tests/test_vcf.py
+++ b/resources/home/dnanexus/generate_workbook/tests/test_vcf.py
@@ -24,7 +24,7 @@ class TestHeader():
     """
     Tests for checking header attributes are correct from parse_header()
     """
-    header_test_vcf = os.path.join(TEST_DATA_DIR, "header_test.vcf")
+    header_test_vcf = os.path.join(TEST_DATA_DIR, "NA12878_unittest.vcf")
 
     # read in header from our test vcf, call functions to parse reference and
     # from read in header


### PR DESCRIPTION
- Fix broken test due to previous change in FOMRAT column suffix from `(FMT)` to `_FMT`
- Align all tests to use same test data for consistency
- Ignore pytest deprecation warnings raised from required escaping characters in subprocess call to `grep` that it is picky about but is needed
- All tests pass:
```
$ python3 -m pytest -v resources/home/dnanexus/generate_workbook/tests/
================================================ test session starts ================================================
platform linux -- Python 3.8.10, pytest-7.0.1, pluggy-1.0.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/jethro/Projects/eggd_vcf2xls_nirvana/resources/home/dnanexus/generate_workbook/tests, configfile: pytest.ini
collected 19 items                                                                                                  

resources/home/dnanexus/generate_workbook/tests/test_columns.py::TestInfoColumn::test_parsed_correct_columns_from_info_records PASSED [  5%]
resources/home/dnanexus/generate_workbook/tests/test_columns.py::TestInfoColumn::test_parsed_correct_gnomADe_AF_values PASSED [ 10%]
resources/home/dnanexus/generate_workbook/tests/test_columns.py::TestFormatSample::test_format_sample_values_are_correct PASSED [ 15%]
resources/home/dnanexus/generate_workbook/tests/test_filters.py::TestModifyingFieldTypes::test_type_correctly_modified PASSED [ 21%]
resources/home/dnanexus/generate_workbook/tests/test_filters.py::TestModifyingFieldTypes::test_header_overwritten_correctly PASSED [ 26%]
resources/home/dnanexus/generate_workbook/tests/test_filters.py::TestFilters::test_filter_with_include_eq PASSED [ 31%]
resources/home/dnanexus/generate_workbook/tests/test_filters.py::TestFilters::test_filter_with_exclude_eq PASSED [ 36%]
resources/home/dnanexus/generate_workbook/tests/test_filters.py::TestFilters::test_filter_with_exclude_gt PASSED [ 42%]
resources/home/dnanexus/generate_workbook/tests/test_filters.py::TestFilters::test_combined_exclude_float_and_string PASSED [ 47%]
resources/home/dnanexus/generate_workbook/tests/test_filters.py::TestFilters::test_combined_filter_and_recover PASSED [ 52%]
resources/home/dnanexus/generate_workbook/tests/test_vcf.py::TestHeader::test_column_names PASSED             [ 57%]
resources/home/dnanexus/generate_workbook/tests/test_vcf.py::TestHeader::test_parse_reference PASSED          [ 63%]
resources/home/dnanexus/generate_workbook/tests/test_vcf.py::TestHeader::test_only_header_parsed PASSED       [ 68%]
resources/home/dnanexus/generate_workbook/tests/test_vcf.py::TestDataFrameActions::test_drop_columns_exclude PASSED [ 73%]
resources/home/dnanexus/generate_workbook/tests/test_vcf.py::TestDataFrameActions::test_drop_columns_include PASSED [ 78%]
resources/home/dnanexus/generate_workbook/tests/test_vcf.py::TestDataFrameActions::test_reorder_columns_correct_order PASSED [ 84%]
resources/home/dnanexus/generate_workbook/tests/test_vcf.py::TestDataFrameActions::test_reorder_columns_no_dropped_columns PASSED [ 89%]
resources/home/dnanexus/generate_workbook/tests/test_vcf.py::TestDataFrameActions::test_non_rename_columns_unaffacted PASSED [ 94%]
resources/home/dnanexus/generate_workbook/tests/test_vcf.py::TestDataFrameActions::test_renamed_correctly PASSED [100%]

================================================ 19 passed in 27.15s ================================================
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_workbook/80)
<!-- Reviewable:end -->
