### PR TITLE
Extra unit test

### DIFF
--- a/resources/home/dnanexus/generate_workbook/tests/test_columns.py
+++ b/resources/home/dnanexus/generate_workbook/tests/test_columns.py
@@ -96,9 +96,8 @@ class TestMainColumns():
         vcf_col = read_column_from_vcf(self.test_vcf, 3)
 
         assert self.vcf_df['ID'].tolist() == vcf_col, (
-            "POS values in df do not match VCF"
+            "ID values in df do not match VCF"
         )
-
 
     def test_ref(self) -> None:
         """
@@ -117,7 +116,7 @@ class TestMainColumns():
         vcf_col = read_column_from_vcf(self.test_vcf, 5)
 
         assert self.vcf_df['ALT'].tolist() == vcf_col, (
-            "REF values in df do not match VCF"
+            "ALT values in df do not match VCF"
         )
 
     def test_qual(self) -> None:
@@ -137,7 +136,7 @@ class TestMainColumns():
         vcf_col = read_column_from_vcf(self.test_vcf, 7)
 
         assert self.vcf_df['FILTER'].tolist() == vcf_col, (
-            "QUAL values in df do not match VCF"
+            "FILTER values in df do not match VCF"
         )
 
 

--- a/resources/home/dnanexus/generate_workbook/tests/test_columns.py
+++ b/resources/home/dnanexus/generate_workbook/tests/test_columns.py
@@ -124,6 +124,7 @@ class TestMainColumns():
         Test the QUAL column is unchanged
         """
         vcf_col = read_column_from_vcf(self.test_vcf, 6)
+        vcf_col = [float(x) for x in vcf_col]  # read in as strings
 
         assert self.vcf_df['QUAL'].tolist() == vcf_col, (
             "QUAL values in df do not match VCF"
@@ -256,6 +257,7 @@ if __name__ == "__main__":
     columns.test_pos()
     columns.test_id()
     columns.test_ref()
+    columns.test_qual()
 
     info = TestInfoColumn()
     info.test_parsed_correct_columns_from_info_records()

--- a/resources/home/dnanexus/generate_workbook/tests/test_columns.py
+++ b/resources/home/dnanexus/generate_workbook/tests/test_columns.py
@@ -257,8 +257,6 @@ if __name__ == "__main__":
     columns.test_pos()
     columns.test_id()
     columns.test_ref()
-    sys.exit()
-
 
     info = TestInfoColumn()
     info.test_parsed_correct_columns_from_info_records()


### PR DESCRIPTION
- unit tests for basic VCF columns to show they are unchanged:
```$ python3 -m pytest -v resources/home/dnanexus/generate_workbook/tests/
================================================ test session starts ================================================
platform linux -- Python 3.8.10, pytest-7.0.1, pluggy-1.0.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/jethro/Projects/eggd_vcf2xls_nirvana/resources/home/dnanexus/generate_workbook/tests, configfile: pytest.ini
collected 27 items                                                                                                  

resources/home/dnanexus/generate_workbook/tests/test_columns.py::test PASSED                                  [  3%]
resources/home/dnanexus/generate_workbook/tests/test_columns.py::TestMainColumns::test_chrom PASSED           [  7%]
resources/home/dnanexus/generate_workbook/tests/test_columns.py::TestMainColumns::test_pos PASSED             [ 11%]
resources/home/dnanexus/generate_workbook/tests/test_columns.py::TestMainColumns::test_id PASSED              [ 14%]
resources/home/dnanexus/generate_workbook/tests/test_columns.py::TestMainColumns::test_ref PASSED             [ 18%]
resources/home/dnanexus/generate_workbook/tests/test_columns.py::TestMainColumns::test_alt PASSED             [ 22%]
resources/home/dnanexus/generate_workbook/tests/test_columns.py::TestMainColumns::test_qual PASSED            [ 25%]
resources/home/dnanexus/generate_workbook/tests/test_columns.py::TestMainColumns::test_filter PASSED          [ 29%]
resources/home/dnanexus/generate_workbook/tests/test_columns.py::TestInfoColumn::test_parsed_correct_columns_from_info_records PASSED [ 33%]
resources/home/dnanexus/generate_workbook/tests/test_columns.py::TestInfoColumn::test_parsed_correct_gnomADe_AF_values PASSED [ 37%]
resources/home/dnanexus/generate_workbook/tests/test_columns.py::TestFormatSample::test_format_sample_values_are_correct PASSED [ 40%]
resources/home/dnanexus/generate_workbook/tests/test_filters.py::TestModifyingFieldTypes::test_type_correctly_modified PASSED [ 44%]
resources/home/dnanexus/generate_workbook/tests/test_filters.py::TestModifyingFieldTypes::test_header_overwritten_correctly PASSED [ 48%]
resources/home/dnanexus/generate_workbook/tests/test_filters.py::TestFilters::test_filter_with_include_eq PASSED [ 51%]
resources/home/dnanexus/generate_workbook/tests/test_filters.py::TestFilters::test_filter_with_exclude_eq PASSED [ 55%]
resources/home/dnanexus/generate_workbook/tests/test_filters.py::TestFilters::test_filter_with_exclude_gt PASSED [ 59%]
resources/home/dnanexus/generate_workbook/tests/test_filters.py::TestFilters::test_combined_exclude_float_and_string PASSED [ 62%]
resources/home/dnanexus/generate_workbook/tests/test_filters.py::TestFilters::test_combined_filter_and_recover PASSED [ 66%]
resources/home/dnanexus/generate_workbook/tests/test_vcf.py::TestHeader::test_column_names PASSED             [ 70%]
resources/home/dnanexus/generate_workbook/tests/test_vcf.py::TestHeader::test_parse_reference PASSED          [ 74%]
resources/home/dnanexus/generate_workbook/tests/test_vcf.py::TestHeader::test_only_header_parsed PASSED       [ 77%]
resources/home/dnanexus/generate_workbook/tests/test_vcf.py::TestDataFrameActions::test_drop_columns_exclude PASSED [ 81%]
resources/home/dnanexus/generate_workbook/tests/test_vcf.py::TestDataFrameActions::test_drop_columns_include PASSED [ 85%]
resources/home/dnanexus/generate_workbook/tests/test_vcf.py::TestDataFrameActions::test_reorder_columns_correct_order PASSED [ 88%]
resources/home/dnanexus/generate_workbook/tests/test_vcf.py::TestDataFrameActions::test_reorder_columns_no_dropped_columns PASSED [ 92%]
resources/home/dnanexus/generate_workbook/tests/test_vcf.py::TestDataFrameActions::test_non_rename_columns_unaffacted PASSED [ 96%]
resources/home/dnanexus/generate_workbook/tests/test_vcf.py::TestDataFrameActions::test_renamed_correctly PASSED [100%]

================================================ 27 passed in 48.53s ================================================

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_workbook/81)
<!-- Reviewable:end -->
