### PR TITLE
Fix reference parsing from header

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -3,7 +3,7 @@
   "title": "eggd_generate_workbook",
   "summary": "Create Excel workbook from VEP annotated vcf",
   "dxapi": "1.0.0",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "authorizedUsers": [
     "org-emee_1"
   ],
@@ -11,7 +11,7 @@
     "org-emee_1"
   ],
   "properties": {
-    "githubRelease": "v2.0.2"
+    "githubRelease": "v2.1.0"
   },
   "inputSpec": [
     {

--- a/dxapp.json
+++ b/dxapp.json
@@ -3,7 +3,7 @@
   "title": "eggd_generate_workbook",
   "summary": "Create Excel workbook from VEP annotated vcf",
   "dxapi": "1.0.0",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "authorizedUsers": [
     "org-emee_1"
   ],
@@ -11,7 +11,7 @@
     "org-emee_1"
   ],
   "properties": {
-    "githubRelease": "v2.0.1"
+    "githubRelease": "v2.0.2"
   },
   "inputSpec": [
     {

--- a/resources/home/dnanexus/generate_workbook/utils/vcf.py
+++ b/resources/home/dnanexus/generate_workbook/utils/vcf.py
@@ -42,6 +42,7 @@ class vcf():
             "csq_cosmic": "https://cancer.sanger.ac.uk/cosmic/search?q=",
             "csq_hgmd": "https://my.qiagendigitalinsights.com/bbp/view/hgmd/pro/mut.php?acc=",
             "csq_mastermind_mmid3": "https://mastermind.genomenon.com/detail?mutation="
+            "gnomad_base_url": "https://gnomad.broadinstitute.org/variant/CHROM-POS-REF-ALT"
         }
 
 
@@ -377,18 +378,22 @@ class vcf():
         Format column value as an Excel hyperlink if URL for column specified
         """
         # some URLs are build specific, infer which to use from build in header
-        reference = self.refs[0].lower()
-        gnomad_base_url = "https://gnomad.broadinstitute.org/variant/CHROM-POS-REF-ALT"
+        if self.refs:
+            reference = self.refs[0].lower()
+        else:
+            # no reference parsed from VCF header(s) => can't infer build
+            reference = ''
+
         build = None
 
         if '37' in reference or 'hg19' in reference:
             self.urls.update({
-                "gnomad": f"{gnomad_base_url}?dataset=gnomad_r2_1"
+                "gnomad": f"{self.gnomad_base_url}?dataset=gnomad_r2_1"
             })
             build = 37
         elif '38' in reference:
             self.urls.update({
-                "gnomad": f"{gnomad_base_url}?dataset=gnomad_r3"
+                "gnomad": f"{self.gnomad_base_url}?dataset=gnomad_r3"
             })
             build = 38
 

--- a/resources/home/dnanexus/generate_workbook/utils/vcf.py
+++ b/resources/home/dnanexus/generate_workbook/utils/vcf.py
@@ -41,7 +41,7 @@ class vcf():
             "csq_clinvar": "https://www.ncbi.nlm.nih.gov/clinvar/variation/",
             "csq_cosmic": "https://cancer.sanger.ac.uk/cosmic/search?q=",
             "csq_hgmd": "https://my.qiagendigitalinsights.com/bbp/view/hgmd/pro/mut.php?acc=",
-            "csq_mastermind_mmid3": "https://mastermind.genomenon.com/detail?mutation="
+            "csq_mastermind_mmid3": "https://mastermind.genomenon.com/detail?mutation=",
             "gnomad_base_url": "https://gnomad.broadinstitute.org/variant/CHROM-POS-REF-ALT"
         }
 


### PR DESCRIPTION
- Fix for bug if no reference parsed from VCF header, an `indexError` was raised due to `self.refs` being an empty list