### PR TITLE
Fixes #92 #94.

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -3,7 +3,7 @@
   "title": "eggd_generate_workbook",
   "summary": "Create Excel workbook from VEP annotated vcf",
   "dxapi": "1.0.0",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "authorizedUsers": [
     "org-emee_1"
   ],
@@ -11,7 +11,7 @@
     "org-emee_1"
   ],
   "properties": {
-    "githubRelease": "v2.0.2"
+    "githubRelease": "v2.0.3"
   },
   "inputSpec": [
     {

--- a/resources/home/dnanexus/generate_workbook/utils/vcf.py
+++ b/resources/home/dnanexus/generate_workbook/utils/vcf.py
@@ -456,8 +456,6 @@ class vcf():
             url = url.replace('REF', str(value.REF))
             url = url.replace('ALT', str(value.ALT))
 
-            return f'=HYPERLINK("{url}", {value[column]})'
-
         elif 'mastermind' in column.lower() or 'mmid3' in column.lower():
             # build URL for MasterMind on genomic position
             # get chromosome NC value for given chrom and build
@@ -475,17 +473,12 @@ class vcf():
             # other URLs with value appended to end
             url = f'{url}{value[column]}'
 
-        if len(f'=HYPERLINK("{url}", "{value[column]}")') > 242:
-            # Excel has a limit of 255 characters inside a formula, display
-            # just the maximum possible of value[column]
-            max_len = 255 - len(f'=HYPERLINK("{url}", ')
-            if max_len > 0:
-                value[column] = value[column][:max_len]
-            else:
-                # URL is too long for excel, just show the value without URL
-                return value[column]
-
-        return f'=HYPERLINK("{url}", "{value[column]}")'
+        if len(url) > 255:
+            # Excel has a string limit of 255 characters inside a formula
+            # If URL is too long just display the value
+            return value[column]
+        else:
+            return f'=HYPERLINK("{url}", "{value[column]}")'
 
 
     def map_chr_to_nc(self, chrom, build) -> str:


### PR DESCRIPTION
Fixes #92 which caused long URLs to break string length rules in excel formulae.
Fixes #94 which caused long URLs truncate values in excel formulae.

Note that this now enforces that the length of the string is no longer than 255, not that the entire formula is no longer that 255 as was previously implemented (since char limit for a cell is actually 32K).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_workbook/93)
<!-- Reviewable:end -->
