### PR TITLE
Renamed app

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -1,6 +1,6 @@
 {
-  "name": "eggd_generate_workbook",
-  "title": "eggd_generate_workbook",
+  "name": "eggd_generate_variant_workbook",
+  "title": "eggd_generate_variant_workbook",
   "summary": "Create Excel workbook from VEP annotated vcf",
   "dxapi": "1.0.0",
   "version": "2.0.3",


### PR DESCRIPTION
Renamed app in dxapp.json to work around `dx build --app` permissions issue

Previous version of app has file permission error which truncates dx describe, and seems to result in nobody having developer permissions:

```
dx describe eggd_generate_workbook
Result 1:
ID                  app-GB5p8K04Q6KbF4gq4Kxf9jg2
Class               app
Billed to           org-emee_1
Name                eggd_generate_workbook
Version             2.0.2
Aliases             2.0.2, default
Created by          jethror1
Created             Mon May 23 16:11:52 2022
Last modified       Thu May 26 13:55:33 2022
Created from        applet-GB7gVQ04XKgBv3P7F03xJ1K7
Installed           false
Open source         false
Deleted             false
Published           Thu May 26 13:55:33 2022
Title               eggd_generate_workbook
Summary             Create Excel workbook from VEP annotated vcf
Categories          -
Details             {}
Access              {"network": ["*"], "project": "CONTRIBUTE", "allProjects": "VIEW"}
API version         1.0.0
Input Spec          app:
                    vcfs (array:file)
                    [clinical_indication (string)]
                generate_workbook.py:
                    [exclude_columns (string)]
                    [include_columns (string)]
                    [reorder_columns (string)]
                    [rename_columns (string)]
                    [types (string)]
                    [filter (string)]
                    [keep_filtered (boolean, default=true)]
                    [keep_tmp (boolean, default=false)]
                    [add_samplename_column (boolean, default=false)]
                    [add_comment_column (boolean, default=false)]
                    [sheet_names (string)]
                    [output_prefix (string)]
                    [merge_vcfs (boolean, default=false)]
                    [summary (string)]
                    [human_filter (string)]
                    [acmg (boolean, default=false)]
                    [print_columns (boolean)]
                    [print_header (boolean)]
                    [panel (string)]
Output Spec         xlsx_report (file)
                [tmp_vcfs (array:file)]
Interpreter         bash
dxpy.exceptions.PermissionDenied: No accessible project could be found containing the entity file-GB7gVJj4XKg0j78p1BVKk4F0, code 401. Request Time=1654605760.2600553, Request ID=1654605760316-648794
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_workbook/95)
<!-- Reviewable:end -->
