### PR TITLE
Fixed gnomad value typing

### DIFF
--- a/resources/home/dnanexus/generate_workbook/utils/vcf.py
+++ b/resources/home/dnanexus/generate_workbook/utils/vcf.py
@@ -478,7 +478,15 @@ class vcf():
             # If URL is too long just display the value
             return value[column]
         else:
-            return f'=HYPERLINK("{url}", "{value[column]}")'
+            if 'gnomad' in column.lower():
+                # Special treatment for gnomad since it contains mixed type
+                # values in hyperlink formulae. Types need to retained
+                # to enable sorting in the workbook
+                return f'=HYPERLINK("{url}", {value[column]})'
+            else:
+                # Values for everything else which is hyperlinked
+                # needs to be cast to string
+                return f'=HYPERLINK("{url}", "{value[column]}")'
 
 
     def map_chr_to_nc(self, chrom, build) -> str:


### PR DESCRIPTION
gnomad values are a mixture of strings (".") and floats (0.01)

Need to retain these types to enable sorting in the output, therefore don't cast them to string as with all other outputs. 

Need to add a more generic solution for data sources with both mixed type values and hyperlinks in a later update - see #96

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_workbook/97)
<!-- Reviewable:end -->
